### PR TITLE
fix subsumption for GHC 9

### DIFF
--- a/src/Data/TypeMap/Dynamic.hs
+++ b/src/Data/TypeMap/Dynamic.hs
@@ -14,6 +14,7 @@ module Data.TypeMap.Dynamic
   , insert
   , (<:)
   , update
+  , alter
   , lookup
   , delete
 

--- a/src/Data/TypeMap/Dynamic/Alt.hs
+++ b/src/Data/TypeMap/Dynamic/Alt.hs
@@ -19,6 +19,7 @@ module Data.TypeMap.Dynamic.Alt
   , (<:)
   , at
   , update
+  , alter
   , lookup
   , delete
 

--- a/src/Data/TypeMap/Internal/Dynamic.hs
+++ b/src/Data/TypeMap/Internal/Dynamic.hs
@@ -87,6 +87,15 @@ update t f (TypeMap m) = TypeMap (Map.update (coerce f) (typeRep t) m)
     coerce :: (Item x t -> Maybe (Item x t)) -> (Any -> Maybe Any)
     coerce = unsafeCoerce
 
+-- | Update a (possibly absent) element indexed by type @t@.
+alter
+  :: forall t x proxy
+  .  Typeable t => proxy t -> (Maybe (Item x t) -> Maybe (Item x t)) -> TypeMap x -> TypeMap x
+alter t f (TypeMap m) = TypeMap (Map.alter (coerce f) (typeRep t) m)
+  where
+    coerce :: (Maybe (Item x t) -> Maybe (Item x t)) -> (Maybe Any -> Maybe Any)
+    coerce = unsafeCoerce
+
 -- | Lookup an element indexed by type @t@.
 lookup
   :: forall t x proxy

--- a/src/Data/TypeMap/Internal/Dynamic/Alt.hs
+++ b/src/Data/TypeMap/Internal/Dynamic/Alt.hs
@@ -62,6 +62,15 @@ update f (TypeMap m) = TypeMap (Map.update (coerce f) (typeRep (Proxy @t)) m)
     coerce :: (Item x t -> Maybe (Item x t)) -> (Any -> Maybe Any)
     coerce = unsafeCoerce
 
+-- | Update a (possibly absent) element indexed by type @t@.
+alter
+  :: forall t x
+  .  Typeable t => (Maybe (Item x t) -> Maybe (Item x t)) -> TypeMap x -> TypeMap x
+alter f (TypeMap m) = TypeMap (Map.alter (coerce f) (typeRep (Proxy @t)) m)
+  where
+    coerce :: (Maybe (Item x t) -> Maybe (Item x t)) -> (Maybe Any -> Maybe Any)
+    coerce = unsafeCoerce
+
 -- | Lookup an element indexed by type @t@.
 lookup
   :: forall t x

--- a/src/Data/TypeMap/Internal/Unsafe.hs
+++ b/src/Data/TypeMap/Internal/Unsafe.hs
@@ -68,7 +68,7 @@ unsafeCons
   .  (Coercible (f Any) (m d), Coercible (f Any) (m ('(a, b) ': d)))
   => (forall c. c -> f c -> f c)
   -> b -> m d -> m ('(a, b) ': d)
-unsafeCons = unsafeCoerce
+unsafeCons = \x -> unsafeCoerce x
 
 -- | Helper to define @snoc@ functions.
 unsafeSnoc
@@ -76,4 +76,4 @@ unsafeSnoc
   .  (Last d ~ '(a, b), Coercible (f Any) (m (Init d)), Coercible (f Any) (m d))
   => (forall c. f c -> c -> f c)
   -> m (Init d) -> b -> m d
-unsafeSnoc = unsafeCoerce
+unsafeSnoc = \x -> unsafeCoerce x


### PR DESCRIPTION
This library no longer compiles under GHC 9, due to [a change](https://downloads.haskell.org/~ghc/9.0.1/docs/html/users_guide/9.0.1-notes.html#language) in RankNTypes' subsumption rules. As suggested by the manual, this is easily fixed by eta expansion.